### PR TITLE
adds to README, runs php-cs-fixer, and fixes frontend controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,38 @@
 
 This is a demo project that implements an Oauth2 server that handles saml2-bearer authorization grants. It mainly uses bshaffer/oauth2-server-php, onelogin/php-saml and codeguy/Slim
 
+### Get Started
+
+1. Clone the repository
+
+    ```
+    # git clone https://github.com/aacotroneo/saml2-bearer-server.git
+    # cd saml2-bearer-server
+    ```
+2. Install all dependencies via composer
+
+    ```
+    # composer install
+    ```
+
+    > Currently, as this is in development, you'll need to update the `bshaffer/oauth2-server-php` dependency to be `aacotroneo/oauth2-server-php`, but this will not be required as soon as we merge PR [#510](https://github.com/bshaffer/oauth2-server-php/pull/510)
+3. Start the PHP web server
+
+    ```
+    # cd web
+    # php -S localhost:9000
+    ```
+4. Open up http://localhost:9000/tokeninfo in your browser!
+
 ### Oauth2-server saml2-bearer authorization grant
 
-We use onelogin/saml to help us with the hard xml validations. I found that is not easy to find a tool in php to make standar-compliant saml2 tokens. Take a look at the comments at the [saml2 config file ] (https://github.com/aacotroneo/saml2-bearer-server/blob/master/inst/saml_settings.php) 
+We use onelogin/saml to help us with the hard xml validations. I found that is not easy to find a tool in php to make standar-compliant saml2 tokens. Take a look at the comments at the [saml2 config file ] (https://github.com/aacotroneo/saml2-bearer-server/blob/master/inst/saml_settings.php)
 
 ### Slim and Oauth2-server
 
 The only problem you may face to integrate both projects is that they both have their own Request and Response. It's never a good thing to have 2 different objects hanging around which represent the same thing, especially the response, which is handled a bit differenty in each library. In slim you just have to echo the response (it's stored with ob_start), while on Oauth2 server you have to 'send()' it explicitely.
 
-To overcome this issue I used a simple adapter pattern, but through inheritance instead of composition so that it is compilant with both interfaces. For example take a look at the [Response Adapter](https://github.com/aacotroneo/saml2-bearer-server/blob/master/src/Oauth2/Http/ResponseAdapter.php) which is the most interesting. Note that Oauth2 server adds params to the response, and slim willl automatically call finalize() when it's the right time. If therer are unsent params, we write a Json, so you won't have to call send() on responses anymore. That's it! 
+To overcome this issue I used a simple adapter pattern, but through inheritance instead of composition so that it is compilant with both interfaces. For example take a look at the [Response Adapter](https://github.com/aacotroneo/saml2-bearer-server/blob/master/src/Oauth2/Http/ResponseAdapter.php) which is the most interesting. Note that Oauth2 server adds params to the response, and slim willl automatically call finalize() when it's the right time. If therer are unsent params, we write a Json, so you won't have to call send() on responses anymore. That's it!
 
 Thank you for reading, and let me know if you any questions, suggestions!
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=5.3.9",
-        "bshaffer/oauth2-server-php": "v1.6", //actually this version does not have saml2-bearer grant.Be sure to change it
+        "bshaffer/oauth2-server-php":"dev-develop",
         "onelogin/php-saml": "v2.3",
         "slim/slim": "2.*",
         "slim/views": "*",

--- a/inst/config.php
+++ b/inst/config.php
@@ -4,8 +4,8 @@ return array(
     'templates.path' => __DIR__ . "/../src/Oauth2/View",
     'view' => new Slim\Views\Twig(),
 
-    'bd' => array(
-        'dsn' => 'pgsql:host=localhost;port=5432;dbname=oauth',
+    'db' => array(
+        'dsn' => 'pgsql:host=localhost;port=5432;dbname=oauth2_server_php',
         'username' => 'postgres',
         'password' => 'postgres'
     ),

--- a/src/Oauth2/Endpoint/AuthorizeEndpoint.php
+++ b/src/Oauth2/Endpoint/AuthorizeEndpoint.php
@@ -4,37 +4,29 @@ namespace Aac\Oauth2\Endpoint;
 use OAuth2\Server;
 use Slim\Slim;
 
-
-class AuthorizeEndpoint extends Endpoint{
-
+class AuthorizeEndpoint extends Endpoint
+{
     /** @var $server Server */
     protected $server;
 
     /**@var $container Slim*/
     protected $container;
 
-
-    function __construct(Slim $container)
+    public function __construct(Slim $container)
     {
         parent::__construct($container);
-        $this->server = $container->servidor;
-
+        $this->server = $container->oauthServer;
     }
 
-    function run (){
-
+    public function run()
+    {
         //@TODO.
         //Just follow original tutorials. Make calls like the following and don't call  $response->send();
         //the response is finalized by slim and correctly handled (note response::send is not part of the interface)
-        //$this->server->validateAuthorizeRequest($this->request, $this->response)
-        //$this->server->handleAuthorizeRequest($this->request, $this->response, $authorized, $userid);
+        // $this->server->validateAuthorizeRequest($this->request, $this->response);
+        // $this->server->handleAuthorizeRequest($this->request, $this->response, $authorized, $userid);
 
         //I wired twig in this setup so you may use
-        //$this->container->render('authorize.twig', $data );
-
+        $this->container->render('authorize.twig');
     }
-
-
-
-
 }

--- a/src/Oauth2/Endpoint/Endpoint.php
+++ b/src/Oauth2/Endpoint/Endpoint.php
@@ -6,10 +6,8 @@ use Aac\Oauth2\Http\RequestAdapter;
 use Aac\Oauth2\Http\ResponseAdapter;
 use Slim\Slim;
 
-
 abstract class Endpoint
 {
-
     /**@var $container Slim */
     protected $container;
     /** @var $request RequestAdapter */
@@ -17,22 +15,18 @@ abstract class Endpoint
     /** @var $response ResponseAdapter */
     protected $response;
 
-
-    function __construct(Slim $container = null)
+    public function __construct(Slim $container = null)
     {
         $this->container = $container;
         $this->request = $this->container->request;
         $this->response = $this->container->response;
     }
 
-    abstract function run();
+    abstract public function run();
 
-
-    function jsonResponse($data, $status = 200)
+    public function jsonResponse($data, $status = 200)
     {
         $this->response->setStatusCode($status);
         $this->response->addParameters($data);
     }
-
-
-} 
+}

--- a/src/Oauth2/Endpoint/TokenEndpoint.php
+++ b/src/Oauth2/Endpoint/TokenEndpoint.php
@@ -1,28 +1,20 @@
 <?php
+
 namespace Aac\Oauth2\Endpoint;
 
-use OAuth2\GrantType\Saml2Bearer;
 use OAuth2\Request;
 use OAuth2\Response;
 use OAuth2\Server;
-use Slim\Slim;
-
 
 class TokenEndpoint extends Endpoint
 {
-
-    function run()
+    public function run()
     {
-
         $server = $this->container->oauthServer;
 
         // Handle a request for an OAuth2.0 Access Token and send the response to the client
         $server->handleTokenRequest($this->request, $this->response);
 
         //yes, this simple!
-
-
     }
-
-
 }

--- a/src/Oauth2/Endpoint/TokenInfoEndpoint.php
+++ b/src/Oauth2/Endpoint/TokenInfoEndpoint.php
@@ -1,15 +1,11 @@
 <?php
 namespace Aac\Oauth2\Endpoint;
 
-
-use Slim\Slim;
-
 class TokenInfoEndpoint extends Endpoint
 {
 
-    function run()
+    public function run()
     {
-
         $server = $this->container->oauthServer;
 
         $token = $server->getAccessTokenData($this->request);
@@ -19,8 +15,5 @@ class TokenInfoEndpoint extends Endpoint
         } else {
             $this->jsonResponse(array('error' => 'Token is invalid or expired'));
         }
-
     }
-
-
 }

--- a/src/Oauth2/Http/RequestAdapter.php
+++ b/src/Oauth2/Http/RequestAdapter.php
@@ -7,8 +7,8 @@ use OAuth2\RequestInterface;
  * A sample adapter to use the same request for slim and bshaffer/Oauth2
  * Class RequestAdapter
  */
-class RequestAdapter extends \Slim\Http\Request implements  RequestInterface{
-
+class RequestAdapter extends \Slim\Http\Request implements  RequestInterface
+{
     public function query($name, $default = null)
     {
         return $this->get($name, $default);

--- a/src/Oauth2/Http/ResponseAdapter.php
+++ b/src/Oauth2/Http/ResponseAdapter.php
@@ -2,16 +2,14 @@
 
 namespace Aac\Oauth2\Http;
 
-
 use OAuth2\ResponseInterface;
 
 /**
  * A sample adapter to use the same request object for slim and bshaffer/Oauth2
  * Class ResponseAdapter
  */
-class ResponseAdapter extends \Slim\Http\Response implements ResponseInterface{
-
-
+class ResponseAdapter extends \Slim\Http\Response implements ResponseInterface
+{
     public function __construct($body = '', $status = 200, $headers = array())
     {
         parent::__construct($body, $status, $headers);
@@ -20,19 +18,19 @@ class ResponseAdapter extends \Slim\Http\Response implements ResponseInterface{
 
     public function finalize()
     {
-        if(!empty($this->parameters)){
+        if (!empty($this->parameters)) {
             $body = $this->getBody();
-            if(!empty($body)){
+            if (!empty($body)) {
                 throw new \Exception("Params where added to the response, but other output was found also");
             }
             $this->body(json_encode($this->parameters));
 
             $this->addHttpHeaders(array("Content-Type" => 'application/json'));
         }
+
        return parent::finalize();
 
     }
-
 
     public function addParameters(array $parameters)
     {

--- a/web/index.php
+++ b/web/index.php
@@ -5,3 +5,5 @@ require_once __DIR__.'/../vendor/autoload.php';
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
+$config = include_once(__DIR__.'/../inst/config.php');
+$app = new Aac\OAuth2\App($config);


### PR DESCRIPTION
Just some small tweaks that I hope improve this library:
- Adds "Get Started" section to README
- ensures Front Controller executes the app
- renames some parameters
- ran `php-cs-fixer`

This looks great! To improve it, I would like to include an endpoint that will generate a SAML assertion so we can quicky and easily test the token endpoint.
